### PR TITLE
benchmarking zip vs naive protobuf

### DIFF
--- a/js/codec/encodeMeasurement-protobuf.js
+++ b/js/codec/encodeMeasurement-protobuf.js
@@ -1,0 +1,15 @@
+"use strict";
+
+var fs = require('fs');
+
+var protobuf = require('protocol-buffers');
+
+
+var messages = protobuf(fs.readFileSync(__dirname + '/measurements.proto'));
+
+
+module.exports = function(measurements){
+    return messages.AffluenceSensorMeasurements.encode({
+        measurements: measurements
+    })
+};

--- a/js/codec/encodeMeasurement-zip.js
+++ b/js/codec/encodeMeasurement-zip.js
@@ -1,0 +1,13 @@
+"use strict";
+
+var zlib = require('zlib');
+
+module.exports = function(measurements){    
+    var input = new Buffer(JSON.stringify(measurements));
+    return new Promise(function(resolve, reject){
+        zlib.deflate(input, function(err, buffer){
+            if(err) reject(err); else resolve(buffer);
+        });
+    });
+}
+

--- a/js/codec/measurements.proto
+++ b/js/codec/measurements.proto
@@ -1,0 +1,8 @@
+message AffluenceSensorMeasurement {
+  required uint32 date = 1;
+  required bytes signal_strengths = 2;
+}
+
+message AffluenceSensorMeasurements {
+  repeated AffluenceSensorMeasurement measurements = 1;
+}

--- a/js/codec/shrinkMeasurementInformation.js
+++ b/js/codec/shrinkMeasurementInformation.js
@@ -1,0 +1,27 @@
+"use strict";
+
+var moment = require('moment')
+var MIN_DATE_UNIX_TIMESTAMP = moment("2015-05-15").unix();
+
+var MIN_SIGNAL_STRENGTH = -110;
+var MAX_SIGNAL_STRENGTH = MIN_SIGNAL_STRENGTH + 255;
+
+function toByte(v){
+    return v - MIN_SIGNAL_STRENGTH;
+}
+
+/*
+    
+*/
+module.exports = function shrinkMeasurementInformation(measurement){
+    var date = moment(measurement.date);
+    var secondTimestamp = date.unix();
+    var recentTimestampSec = secondTimestamp - MIN_DATE_UNIX_TIMESTAMP 
+    
+    var recentTimestampMin = Math.floor(recentTimestampSec/60);
+    
+    return {
+        date: recentTimestampMin,
+        signal_strengths: new Buffer(measurement.signal_strengths.map(toByte))
+    };
+};

--- a/js/codec/test.js
+++ b/js/codec/test.js
@@ -1,0 +1,55 @@
+"use strict";
+
+require('es6-shim');
+
+var shrinkMeasurementInformation = require('./shrinkMeasurementInformation');
+
+var encodeProto = require('./encodeMeasurement-protobuf');
+var encodeZip = require('./encodeMeasurement-zip');
+
+var measurements = [
+    {
+        date: new Date('2015-05-15T14:38:00+02:00'),
+        signal_strengths: [-60, -63, -75, -40, -64, -70, -66, -82, -70, -80, -91, -73, -23, -83, -73, -76, -74, -72, -70, -68, -66, -67, -67, -65, -65, -63, -55, -57, -61, -48, -53, -54, -48, -45, -36, -40, -41]
+    },
+    {
+        date: new Date('2015-05-15T14:39:00+02:00'),
+        signal_strengths: [-60,-63,-75,-40,-64,-70,-82,-66,-82,-70,-80,-91,-73,-
+23,-83,-73,-76,-74,-72,-70,-68,-66,-67,-67,-65,-65,-63,-55,-57,-61,-48,-53,-54,-
+48,-45,-36,-40,-41]
+    },
+    {
+        date: new Date('2015-05-15T14:40:00+02:00'),
+        signal_strengths: [-60,-63,-75,-40,-64,-70,-82,-66,-82,-70,-80,-91,-73,-
+23,-83,-73,-76,-74,-72,-70,-68,-66,-67,-67,-65,-65,-63,-55,-57,-61,-48,-53,-54,-
+48,-45,-36,-40,-41]
+    },
+    {
+        date: new Date('2015-05-15T14:41:00+02:00'),
+        signal_strengths: [-60,-63,-75,-40,-64,-70,-82,-72,-70,-80,-91,-73,-23,-
+83,-73,-76,-74,-72,-70,-68,-66,-67,-67,-65,-65,-63,-55,-57,-61,-48,-53,-54,-48,-
+45,-36,-40,-41]
+    },
+    {
+        date: new Date('2015-05-15T14:42:00+02:00'),
+        signal_strengths: [-60,-63,-75,-40,-64,-70,-91,-73,-23,-83,-73,-76,-74,-
+72,-70,-68,-66,-67,-67,-65,-65,-63,-55,-57,-61,-48,-53,-54,-48,-45,-36,-40,-41]
+    }
+];
+
+var shrinkedMessages = measurements.map(shrinkMeasurementInformation);
+
+console.log('ref JSON', JSON.stringify(shrinkedMessages).length);
+
+var protobuf_based_buffer = encodeProto(shrinkedMessages);
+var zip_based_bufferP = encodeZip(shrinkedMessages);
+
+zip_based_bufferP.then(function(zip_based_buffer){
+    console.log('pbuf VS zip', protobuf_based_buffer.length, zip_based_buffer.length);
+    console.log(protobuf_based_buffer);
+    console.log(zip_based_buffer);
+})
+
+
+
+

--- a/package.json
+++ b/package.json
@@ -15,8 +15,10 @@
     "es6-shim": "^0.31.0",
     "fast-csv": "^0.6.0",
     "machina": "^1.0.0",
+    "moment": "^2.10.3",
     "moment-timezone": "^0.3.1",
     "node-watch": "^0.3.4",
+    "protocol-buffers": "^3.0.0",
     "split": "^0.3.3",
     "through": "^2.3.7"
   }


### PR DESCRIPTION
```
ref JSON 720
pbuf VS zip 218 144
```

Zip wins hands down (because @iOiurson is annoying) for now.

Depending on the level of precision we want/expect, we may be able to compress measured strengths. Another idea if measure order doesn't matter is to sort the array, send the first (smallest) value and only (4-bits?) deltas from there (and `0b1111` as escape for next value).
