### PR TITLE
Modifying protobuf message description (-2 bytes), and try protobuf+zip

### DIFF
--- a/js/codec/delta-encode.js
+++ b/js/codec/delta-encode.js
@@ -1,0 +1,58 @@
+"use strict";
+
+/*
+    values is an asc sorted array of integer [0, 255] (1-byte)
+    delta encoding consists in providing the first value and then only increments to the previous value.
+    increments are stored in 4-bits. 0b1111 is an escape value if the delta between 2 values is >=15; in that case, the next byte is a new value
+*/
+
+module.exports = function(values){
+    // allocate a buffer purposefully too big
+    var buffer = new Buffer(2*values.length);
+    var nextIndex = 0;
+    var byteBeingBuilt;
+    var previousValue; // undefined indicates next values should be written in full, not delta
+    
+    values.forEach(function(v){
+        if(previousValue === undefined){
+            buffer.writeUInt8(v, nextIndex++);
+            previousValue = v;
+            return;
+        }
+        
+        var delta = v - previousValue;
+        
+        if(delta >= 0x0F){
+            // write 0xF
+            if(byteBeingBuilt !== undefined)
+                byteBeingBuilt += 0x0F;
+            else
+                byteBeingBuilt = 0x0F << 4;
+            
+            buffer.writeUInt8(byteBeingBuilt, nextIndex++);
+            buffer.writeUInt8(v, nextIndex++);
+            byteBeingBuilt = undefined;
+        }
+        else{
+            if(byteBeingBuilt !== undefined){
+                byteBeingBuilt += delta;
+                buffer.writeUInt8(byteBeingBuilt, nextIndex++);
+                byteBeingBuilt = undefined;
+            }
+            else
+                byteBeingBuilt = delta << 4;
+        }
+        
+        previousValue = v;
+            
+    });
+    
+    // in case we ended with a leftover semi-byte, pad with 0x0F
+    if(byteBeingBuilt !== undefined){
+        byteBeingBuilt += 0x0F;
+        buffer.writeUInt8(byteBeingBuilt, nextIndex++);
+        byteBeingBuilt = undefined;
+    }
+    
+    return buffer.slice(0, nextIndex);
+}

--- a/js/codec/delta-encoded-measurements.proto
+++ b/js/codec/delta-encoded-measurements.proto
@@ -1,0 +1,8 @@
+message AffluenceSensorMeasurement {
+  required uint32 date = 1;
+  required bytes signal_strengths = 2 [packed=true];
+}
+
+message AffluenceSensorMeasurements {
+  repeated AffluenceSensorMeasurement measurements = 1 [packed=true];
+}

--- a/js/codec/encodeMeasurement-delta-protobuf.js
+++ b/js/codec/encodeMeasurement-delta-protobuf.js
@@ -1,0 +1,20 @@
+"use strict";
+
+var fs = require('fs');
+
+var protobuf = require('protocol-buffers');
+
+var deltaEncode = require('./delta-encode');
+
+var messages = protobuf(fs.readFileSync(__dirname + '/delta-encoded-measurements.proto'));
+
+module.exports = function(measurements){
+    return messages.AffluenceSensorMeasurements.encode({
+        measurements: measurements.map(function(measurement){
+            return {
+                date: measurement.date,
+                signal_strengths : deltaEncode(measurement.signal_strengths)
+            }
+        })
+    });
+};

--- a/js/codec/measurements.proto
+++ b/js/codec/measurements.proto
@@ -1,8 +1,8 @@
 message AffluenceSensorMeasurement {
   required uint32 date = 1;
-  required bytes signal_strengths = 2;
+  repeated uint32 signal_strengths = 2 [packed=true];
 }
 
 message AffluenceSensorMeasurements {
-  repeated AffluenceSensorMeasurement measurements = 1;
+  repeated AffluenceSensorMeasurement measurements = 1 [packed=true];
 }

--- a/js/codec/shrinkMeasurementInformation.js
+++ b/js/codec/shrinkMeasurementInformation.js
@@ -22,6 +22,6 @@ module.exports = function shrinkMeasurementInformation(measurement){
     
     return {
         date: recentTimestampMin,
-        signal_strengths: new Buffer(measurement.signal_strengths.map(toByte))
+        signal_strengths: measurement.signal_strengths.map(toByte)
     };
 };

--- a/js/codec/shrinkMeasurementInformation.js
+++ b/js/codec/shrinkMeasurementInformation.js
@@ -22,6 +22,8 @@ module.exports = function shrinkMeasurementInformation(measurement){
     
     return {
         date: recentTimestampMin,
-        signal_strengths: measurement.signal_strengths.map(toByte)
+        signal_strengths: measurement.signal_strengths.map(toByte).sort(function(a, b){
+            return a < b ? -1 : 1;
+        })
     };
 };

--- a/js/codec/test.js
+++ b/js/codec/test.js
@@ -51,5 +51,21 @@ zip_based_bufferP.then(function(zip_based_buffer){
 })
 
 
+var zlib = require('zlib');
+
+var protobuf_and_zip_based_bufferP = new Promise(function(resolve, reject){
+    zlib.deflate(protobuf_based_buffer, function(err, buffer){
+        if(err) reject(err); else resolve(buffer);
+    });
+});
+
+protobuf_and_zip_based_bufferP.then(function(bothBuf){
+    console.log('bothBuf', bothBuf.length);
+})
+
+    
+    
+
+
 
 

--- a/js/codec/test.js
+++ b/js/codec/test.js
@@ -2,9 +2,12 @@
 
 require('es6-shim');
 
+var zlib = require('zlib');
+
 var shrinkMeasurementInformation = require('./shrinkMeasurementInformation');
 
 var encodeProto = require('./encodeMeasurement-protobuf');
+var encodeProtoDelta = require('./encodeMeasurement-delta-protobuf');
 var encodeZip = require('./encodeMeasurement-zip');
 
 var measurements = [
@@ -42,16 +45,18 @@ var shrinkedMessages = measurements.map(shrinkMeasurementInformation);
 console.log('ref JSON', JSON.stringify(shrinkedMessages).length);
 
 var protobuf_based_buffer = encodeProto(shrinkedMessages);
+var delta_protobuf_based_buffer = encodeProtoDelta(shrinkedMessages);
 var zip_based_bufferP = encodeZip(shrinkedMessages);
 
 zip_based_bufferP.then(function(zip_based_buffer){
-    console.log('pbuf VS zip', protobuf_based_buffer.length, zip_based_buffer.length);
-    console.log(protobuf_based_buffer);
-    console.log(zip_based_buffer);
+    console.log('naive-protobuf', protobuf_based_buffer.length);
+    console.log('delta_protobuf', delta_protobuf_based_buffer.length);
+    console.log('zip', zip_based_buffer.length);
+    //console.log(protobuf_based_buffer);
+    //console.log(zip_based_buffer);
 })
 
 
-var zlib = require('zlib');
 
 var protobuf_and_zip_based_bufferP = new Promise(function(resolve, reject){
     zlib.deflate(protobuf_based_buffer, function(err, buffer){
@@ -60,11 +65,21 @@ var protobuf_and_zip_based_bufferP = new Promise(function(resolve, reject){
 });
 
 protobuf_and_zip_based_bufferP.then(function(bothBuf){
-    console.log('bothBuf', bothBuf.length);
-})
+    console.log('naive-protobuf + zip', bothBuf.length);
+});
 
     
     
+
+var delta_protobuf_and_zip_based_bufferP = new Promise(function(resolve, reject){
+    zlib.deflate(delta_protobuf_based_buffer, function(err, buffer){
+        if(err) reject(err); else resolve(buffer);
+    });
+});
+
+delta_protobuf_and_zip_based_bufferP.then(function(bothBuf){
+    console.log('delta-protobuf + zip', bothBuf.length);
+});
 
 
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Counting wifi searching devices",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "mocha test/*",
     "prepare": "sh shell/preinstall.sh",
     "monitor": "sh shell/runMonitoring.sh"
   },
@@ -21,5 +21,10 @@
     "protocol-buffers": "^3.0.0",
     "split": "^0.3.3",
     "through": "^2.3.7"
+  },
+  "devDependencies": {
+    "chai": "^2.3.0",
+    "chai-as-promised": "^5.0.0",
+    "mocha": "^2.2.5"
   }
 }

--- a/test/delta-encode.js
+++ b/test/delta-encode.js
@@ -1,0 +1,63 @@
+"use strict";
+
+require('es6-shim');
+
+var assert = assert = require('chai').assert;
+
+var deltaEncode = require('../js/codec/delta-encode');
+
+describe('delta-encode', function(){
+    
+    it('should encode the unique value if there is only one value', function(){
+        var b = deltaEncode([10]);
+        
+        assert.strictEqual(b.length, 1);
+        assert.strictEqual(b[0], 10);
+    });
+    
+    it('should encode the value and 0x00 if 3 equal values are passed', function(){
+        var b = deltaEncode([14, 14, 14]);
+        
+        assert.strictEqual(b.length, 2);
+        assert.strictEqual(b[0], 14);
+        assert.strictEqual(b[1], 0x00);
+    });
+    
+    it('should encode the value and 0x10 for [14, 15, 15]', function(){
+        var b = deltaEncode([14, 15, 15]);
+        
+        assert.strictEqual(b.length, 2);
+        assert.strictEqual(b[0], 14);
+        assert.strictEqual(b[1], 0x10);
+    });
+    
+    it('should encode the value and 0x1F for [14, 15]', function(){
+        var b = deltaEncode([14, 15]);
+        
+        assert.strictEqual(b.length, 2);
+        assert.strictEqual(b[0], 14);
+        assert.strictEqual(b[1], 0x1F);
+    });
+    
+    it('should encode the 0, 0xF0 and 17 for [0, 17]', function(){
+        var b = deltaEncode([0, 17]);
+        
+        assert.strictEqual(b.length, 3);
+        assert.strictEqual(b[0], 0);
+        assert.strictEqual(b[1], 0xF0);
+        assert.strictEqual(b[2], 17);
+    });
+    
+    it('should encode the 0, 0xF0, 17, 0x0F, 80 for [0, 17, 17, 80]', function(){
+        var b = deltaEncode([0, 17, 17, 80]);
+        
+        assert.strictEqual(b.length, 5);
+        assert.strictEqual(b[0], 0);
+        assert.strictEqual(b[1], 0xF0);
+        assert.strictEqual(b[2], 17);
+        assert.strictEqual(b[3], 0x0F);
+        assert.strictEqual(b[4], 80);
+    });
+    
+    
+});


### PR DESCRIPTION
```
ref JSON 720
pbuf VS zip 216 144
bothBuf 89
```

Doing protobuf, then zip yields a 89-bytes message on the current benchmark (which is decently representative how what we'll have).
This fits in an SMS even base64 encoded \o/

I'm sure @iOiurson will agree this wins hands **down**! ;-)
