### PR TITLE
v1.0.4: Fixed a bug with bluetooth pauserecord

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "6sense",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Counting wifi/bluetooth devices",
   "main": "./src/index.js",
   "scripts": {

--- a/src/bluetooth/initBluetooth.sh
+++ b/src/bluetooth/initBluetooth.sh
@@ -3,4 +3,4 @@
 # Here, put the script needed to power the bluetooth dongle on.
 # The script by default is made for archlinux.
 
-echo -e 'power on\nexit' | bluetoothctl
+echo -e 'power off\npower on\nexit' | bluetoothctl


### PR DESCRIPTION
When trying to pause measurements, if noble didn't send the `stopScanning` event (dongle disconnected, etc...), the sensor kept sending data.
